### PR TITLE
Fix asset and service worker paths for GitHub Pages deployment

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,52 +9,32 @@
     <meta name="author" content="Suno Prompt Engine" />
 
     <!-- PWA Meta Tags -->
-    <link rel="manifest" href="/manifest.webmanifest" />
+    <link rel="manifest" href="%BASE_URL%manifest.webmanifest" />
     <meta name="theme-color" content="#8b5cf6" />
     <meta name="apple-mobile-web-app-capable" content="yes" />
     <meta name="mobile-web-app-capable" content="yes" />
     <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
     <meta name="apple-mobile-web-app-title" content="Suno Engine" />
-    <link rel="apple-touch-icon" href="/pwa-192x192.png" />
+    <link rel="apple-touch-icon" href="%BASE_URL%pwa-192x192.png" />
     
     <!-- Favicon -->
-    <link rel="icon" href="/pwa-192x192.png" type="image/png">
+    <link rel="icon" href="%BASE_URL%pwa-192x192.png" type="image/png">
 
     <!-- Open Graph -->
     <meta property="og:title" content="Suno Prompt Engine - AI Music Prompt Builder" />
     <meta property="og:description" content="AI-powered Suno prompt builder with OpenRouter. Create precise Suno v4.5 prompts using curated metatag system." />
     <meta property="og:type" content="website" />
-    <meta property="og:image" content="/pwa-512x512.png" />
+    <meta property="og:image" content="%BASE_URL%pwa-512x512.png" />
 
     <!-- Twitter Card -->
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="Suno Prompt Engine" />
     <meta name="twitter:description" content="AI-powered Suno prompt builder with OpenRouter" />
-    <meta name="twitter:image" content="/pwa-512x512.png" />
+    <meta name="twitter:image" content="%BASE_URL%pwa-512x512.png" />
   </head>
 
   <body>
     <div id="root"></div>
     <script type="module" src="/src/main.tsx"></script>
-    
-    <!-- Service Worker Registration -->
-    <script>
-      // Register the service worker on secure contexts (HTTPS or localhost)
-      (function () {
-        const isLocalhost = /(?:localhost|127\.0\.0\.1|::1)/.test(location.hostname);
-        const isSecure = location.protocol === 'https:' || isLocalhost;
-        if ('serviceWorker' in navigator && isSecure) {
-          window.addEventListener('load', () => {
-            navigator.serviceWorker.register('/sw.js')
-              .then((registration) => {
-                console.log('SW registered: ', registration);
-              })
-              .catch((registrationError) => {
-                console.log('SW registration failed: ', registrationError);
-              });
-          });
-        }
-      })();
-    </script>
   </body>
 </html>

--- a/public/manifest.webmanifest
+++ b/public/manifest.webmanifest
@@ -2,8 +2,8 @@
   "name": "Suno Prompt Engine - AI Music Prompt Builder",
   "short_name": "Suno Engine",
   "description": "AI Suno prompt builder using curated metatag system.",
-  "start_url": "/",
-  "scope": "/",
+  "start_url": "./",
+  "scope": "./",
   "display": "standalone",
   "orientation": "portrait",
   "background_color": "#0f0f23",
@@ -12,13 +12,13 @@
   "lang": "en-US",
   "icons": [
     {
-      "src": "/pwa-192x192.png",
+      "src": "pwa-192x192.png",
       "sizes": "192x192",
       "type": "image/png",
       "purpose": "any maskable"
     },
     {
-      "src": "/pwa-512x512.png",
+      "src": "pwa-512x512.png",
       "sizes": "512x512",
       "type": "image/png",
       "purpose": "any maskable"
@@ -26,13 +26,13 @@
   ],
   "screenshots": [
     {
-      "src": "/screenshot-desktop.png",
+      "src": "screenshot-desktop.png",
       "sizes": "512x512",
       "type": "image/png",
       "form_factor": "wide"
     },
     {
-      "src": "/screenshot-mobile.png",
+      "src": "screenshot-mobile.png",
       "sizes": "512x512",
       "type": "image/png",
       "form_factor": "narrow"
@@ -43,10 +43,10 @@
       "name": "Create New Prompt",
       "short_name": "New Prompt",
       "description": "Start creating a new Suno prompt",
-      "url": "/",
+      "url": "./",
       "icons": [
         {
-          "src": "/pwa-192x192.png",
+          "src": "pwa-192x192.png",
           "sizes": "192x192"
         }
       ]

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,10 +1,18 @@
 const CACHE_NAME = 'suno-prompt-engine-v3';
+
+const BASE_URL = (() => {
+  const { pathname } = self.location;
+  return pathname.endsWith('sw.js')
+    ? pathname.slice(0, -'sw.js'.length)
+    : new URL('./', self.location).pathname;
+})();
+
 const PRECACHE = [
-  '/',
-  '/index.html',
-  '/manifest.webmanifest',
-  '/pwa-192x192.png',
-  '/pwa-512x512.png'
+  BASE_URL,
+  `${BASE_URL}index.html`,
+  `${BASE_URL}manifest.webmanifest`,
+  `${BASE_URL}pwa-192x192.png`,
+  `${BASE_URL}pwa-512x512.png`,
 ];
 
 self.addEventListener('install', event => {
@@ -61,8 +69,11 @@ self.addEventListener('fetch', (event) => {
     }
 
     if (req.mode === 'navigate') {
-      const shell = await cache.match('/');
+      const shell = await cache.match(new URL(BASE_URL, self.location.origin));
       if (shell) return shell;
+
+      const shellHtml = await cache.match(new URL(`${BASE_URL}index.html`, self.location.origin));
+      if (shellHtml) return shellHtml;
     }
 
     return new Response('', { status: 504, statusText: 'Gateway Timeout' });

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -3,3 +3,23 @@ import App from './App.tsx'
 import './index.css'
 
 createRoot(document.getElementById("root")!).render(<App />);
+
+if ('serviceWorker' in navigator) {
+  const isLocalhost = /(?:localhost|127\.0\.0\.1|::1)/.test(window.location.hostname);
+  const isSecure = window.location.protocol === 'https:' || isLocalhost;
+
+  if (isSecure) {
+    window.addEventListener('load', () => {
+      const swUrl = `${import.meta.env.BASE_URL}sw.js`;
+
+      navigator.serviceWorker
+        .register(swUrl)
+        .then((registration) => {
+          console.log('SW registered: ', registration);
+        })
+        .catch((registrationError) => {
+          console.log('SW registration failed: ', registrationError);
+        });
+    });
+  }
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -5,6 +5,7 @@ import { componentTagger } from "lovable-tagger";
 
 // https://vitejs.dev/config/
 export default defineConfig(({ mode }) => ({
+  base: mode === 'development' ? '/' : '/sonic-prompt-gen/',
   server: {
     host: "::",
     port: 8080,


### PR DESCRIPTION
## Summary
- configure Vite to use the GitHub Pages base path while keeping local development unaffected
- update PWA manifest, HTML meta tags, and service worker logic to resolve assets relative to the deployed base URL
- move service worker registration into the React entry point so it can leverage the base-aware URL

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cde7e8e96c832a8a9f6d13740a366b